### PR TITLE
correct function call of badger.DefaultOptions()

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"github.com/sarahc0nn0r/ultranet/backend/lib"
 	"log"
 	"math"
 	"math/rand"
@@ -14,7 +15,6 @@ import (
 	"reflect"
 	"strings"
 	"time"
-	"ultranet/backend/lib"
 
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/btcd_lib"
@@ -522,8 +522,8 @@ func main() {
 		}
 	}()
 
-	opts := badger.DefaultOptions
-	opts.Dir = lib.GetBadgerDbPath(dataDir)
+	dir := lib.GetBadgerDbPath(dataDir)
+	opts := badger.DefaultOptions(dir)
 	opts.Truncate = true
 	opts.ValueDir = lib.GetBadgerDbPath(dataDir)
 	glog.Infof("BadgerDB Dir: %v", opts.Dir)


### PR DESCRIPTION
changed import path of "ultranet/backend/lib"
to "github.com/sarahc0nn0r/ultranet/backend/lib".
correct function call of badger.DefaultOptions()
with default directory as parameter. This fix allow backend to be build from a freshly cloned repo.